### PR TITLE
feat: gestionar cambio y reseteo de contraseñas

### DIFF
--- a/frontend/src/components/CambiarContraseña.tsx
+++ b/frontend/src/components/CambiarContraseña.tsx
@@ -1,0 +1,52 @@
+import { useContext, useState } from 'react';
+import axios from 'axios';
+import { AuthContext } from '../context/AuthContext';
+
+export default function CambiarContraseña() {
+  const { token } = useContext(AuthContext);
+  const [contraseñaActual, setContraseñaActual] = useState('');
+  const [nuevaContraseña, setNuevaContraseña] = useState('');
+  const [mensaje, setMensaje] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await axios.put(
+        'http://localhost:3000/usuarios/password',
+        { contraseñaActual, nuevaContraseña },
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      setMensaje('Contraseña actualizada correctamente');
+      setContraseñaActual('');
+      setNuevaContraseña('');
+    } catch (err) {
+      console.error(err);
+      setMensaje('Error al actualizar la contraseña');
+    }
+  };
+
+  return (
+    <div style={{ padding: 20 }}>
+      <h3>Cambiar contraseña</h3>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="password"
+          placeholder="Contraseña actual"
+          value={contraseñaActual}
+          onChange={(e) => setContraseñaActual(e.target.value)}
+          required
+        /><br />
+        <input
+          type="password"
+          placeholder="Nueva contraseña"
+          value={nuevaContraseña}
+          onChange={(e) => setNuevaContraseña(e.target.value)}
+          required
+        /><br />
+        <button type="submit" className="editar">Guardar</button>
+      </form>
+      {mensaje && <p>{mensaje}</p>}
+    </div>
+  );
+}
+

--- a/frontend/src/components/FormularioUsuario.tsx
+++ b/frontend/src/components/FormularioUsuario.tsx
@@ -32,13 +32,17 @@ export default function FormularioUsuario({ usuarioInicial, onGuardar, onCancela
   useEffect(() => {
     if (usuarioInicial) {
       const { nombre, email, rol } = usuarioInicial;
-      setForm({ nombre, email, rol });
+      setForm({ nombre, email, rol, password: '' });
     }
   }, [usuarioInicial]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onGuardar(form);
+    const data = { ...form };
+    if (!data.password) {
+      delete data.password;
+    }
+    onGuardar(data);
   };
 
   return (
@@ -69,15 +73,24 @@ export default function FormularioUsuario({ usuarioInicial, onGuardar, onCancela
             <option value="tecnico">Técnico</option>
             <option value="cliente">Cliente</option>
           </select><br />
-          {!usuarioInicial && (
+          {usuarioInicial ? (
             <>
-            <input
-              type="password"
-              placeholder="Contraseña"
-              value={form.password || ''}
-              onChange={(e) => setForm({ ...form, password: e.target.value })}
-              required
-            /><br />
+              <input
+                type="password"
+                placeholder="Nueva contraseña (opcional)"
+                value={form.password || ''}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+              /><br />
+            </>
+          ) : (
+            <>
+              <input
+                type="password"
+                placeholder="Contraseña"
+                value={form.password || ''}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                required
+              /><br />
             </>
           )}
           <br />

--- a/frontend/src/components/UsuariosPanel.tsx
+++ b/frontend/src/components/UsuariosPanel.tsx
@@ -40,6 +40,7 @@ export default function UsuariosPanel() {
       setUsuarioSeleccionado(undefined);
       cargarUsuarios();
     } catch (err) {
+      console.error(err);
       alert('Error al guardar usuario');
     }
   };
@@ -52,7 +53,22 @@ export default function UsuariosPanel() {
       });
       cargarUsuarios();
     } catch (err) {
+      console.error(err);
       alert('Error al eliminar usuario');
+    }
+  };
+
+  const resetearPassword = async (id_usuario: number) => {
+    try {
+      const res = await axios.put(
+        `http://localhost:3000/usuarios/${id_usuario}/password`,
+        {},
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      alert(`Contraseña temporal: ${res.data.password}`);
+    } catch (err) {
+      console.error(err);
+      alert('Error al resetear contraseña');
     }
   };
 
@@ -89,6 +105,10 @@ export default function UsuariosPanel() {
               </button>{' '}
               <button className="eliminar" onClick={() => eliminarUsuario(u.id_usuario)}>
                 Eliminar
+              </button>
+              {' '}
+              <button className="editar" onClick={() => resetearPassword(u.id_usuario)}>
+                Resetear contraseña
               </button>
             </div>
           </div>

--- a/frontend/src/views/Panel.tsx
+++ b/frontend/src/views/Panel.tsx
@@ -6,6 +6,7 @@ import OficinasPanel from '../components/OficinasPanel';
 import DispositivosPanel from '../components/DispositivosPanel';
 import ServiciosPanel from '../components/ServiciosPanel';
 import UsuariosPanel from '../components/UsuariosPanel';
+import CambiarContraseña from '../components/CambiarContraseña';
 
 
 export default function Panel() {
@@ -33,6 +34,7 @@ export default function Panel() {
         <button onClick={() => setVista('dispositivos')}>Dispositivos</button>{' '}
         <button onClick={() => setVista('servicios')}>Servicios</button>{' '}
         <button onClick={() => setVista('usuarios')}>Usuarios</button>{' '}
+        <button onClick={() => setVista('cambiarPassword')}>Cambiar contraseña</button>{' '}
         {/* BOTON PARA CERRAR SESION */}
         <button onClick={cerrarSesion}>Cerrar sesión</button>
       </div>
@@ -43,6 +45,7 @@ export default function Panel() {
       {vista === 'dispositivos' && <DispositivosPanel />}
       {vista === 'servicios' && <ServiciosPanel />}
       {vista === 'usuarios' && <UsuariosPanel />}
+      {vista === 'cambiarPassword' && <CambiarContraseña />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add user password change component and route in panel
- enable admins to reset passwords from usuarios panel
- allow editing user password when updating a user

## Testing
- `npx eslint src/components/CambiarContraseña.tsx src/components/UsuariosPanel.tsx src/components/FormularioUsuario.tsx src/views/Panel.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a7ac7d6eec832a86ecfe216b1326ee