### PR TITLE
feat: add admin password reset

### DIFF
--- a/backend/controllers/usuariosController.js
+++ b/backend/controllers/usuariosController.js
@@ -55,3 +55,22 @@ exports.eliminarUsuario = (req, res) => {
     res.json({ mensaje: 'Usuario eliminado correctamente' });
   });
 };
+
+exports.blanquearContraseña = async (req, res) => {
+  const { id } = req.params;
+
+  const contraseñaTemporal = Math.random().toString(36).slice(-8);
+
+  try {
+    const contraseñaHasheada = await bcrypt.hash(contraseñaTemporal, 10);
+    const sql = 'UPDATE usuarios SET contraseña = ? WHERE id_usuario = ?';
+    db.query(sql, [contraseñaHasheada, id], (err) => {
+      if (err) {
+        return res.status(500).json({ error: 'Error al actualizar contraseña' });
+      }
+      res.json({ contraseñaTemporal });
+    });
+  } catch (error) {
+    res.status(500).json({ error: 'Error al blanquear contraseña' });
+  }
+};

--- a/backend/routes/usuarios.js
+++ b/backend/routes/usuarios.js
@@ -7,6 +7,7 @@ const { authMiddleware, roleMiddleware } = require('../middlewares/authMiddlewar
 router.get('/', authMiddleware, roleMiddleware('admin'), usuariosController.listarUsuarios);
 router.post('/', authMiddleware, roleMiddleware('admin'), usuariosController.crearUsuario);
 router.put('/:id', authMiddleware, roleMiddleware('admin'), usuariosController.modificarUsuario);
+router.put('/:id/password', authMiddleware, roleMiddleware('admin'), usuariosController.blanquearContraseña);
 router.delete('/:id', authMiddleware, roleMiddleware('admin'), usuariosController.eliminarUsuario);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- allow administrators to reset a user's password and receive a temporary one
- expose password reset endpoint

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ac7bbd94832abdc92cc08e0cb169