### PR TITLE
feat: add password change endpoint

### DIFF
--- a/backend/routes/usuarios.js
+++ b/backend/routes/usuarios.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const usuariosController = require('../controllers/usuariosController');
 const { authMiddleware, roleMiddleware } = require('../middlewares/authMiddleware');
 
+router.put('/password', authMiddleware, usuariosController.cambiarContraseña);
+
 // Solo admins pueden tocar usuarios
 router.get('/', authMiddleware, roleMiddleware('admin'), usuariosController.listarUsuarios);
 router.post('/', authMiddleware, roleMiddleware('admin'), usuariosController.crearUsuario);


### PR DESCRIPTION
## Summary
- allow users to update their password after verifying the current one
- expose PUT /password route for authenticated users

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68a7ac798b50832a9f72121cf6179bc5