### PR TITLE
Restringir servicios listados según técnico autenticado

### DIFF
--- a/backend/controllers/serviciosController.js
+++ b/backend/controllers/serviciosController.js
@@ -2,7 +2,15 @@ const db = require('../config/db');
 
 // GET /servicios
 exports.listarServicios = (req, res) => {
-  db.query('SELECT * FROM servicios', (err, resultados) => {
+  const { rol, id } = req.usuario || {};
+
+  // Los técnicos solo ven los servicios asignados a ellos; admin ve todo
+  const sql = rol === 'tecnico'
+    ? 'SELECT * FROM servicios WHERE id_usuario = ?'
+    : 'SELECT * FROM servicios';
+  const params = rol === 'tecnico' ? [id] : [];
+
+  db.query(sql, params, (err, resultados) => {
     if (err) return res.status(500).json({ error: 'Error al listar servicios' });
     res.json(resultados);
   });


### PR DESCRIPTION
## Summary
- limitamos el endpoint de listado de servicios para que los técnicos solo reciban los casos asignados a su usuario, manteniendo a los administradores con acceso completo

## Testing
- no se agregaron pruebas automatizadas


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69329acb55e4832a89c59c2dfef60062)